### PR TITLE
Change sorting buttons

### DIFF
--- a/_lib/cms/_tpl/list.php
+++ b/_lib/cms/_tpl/list.php
@@ -63,7 +63,7 @@ foreach( $where as $k=>$v ){
 <tbody id="items_<?=underscored($this->section);?>">
 <tr>
 	<? if( $sortable ){ ?>
-		<th width="37" class="sorting-arrows">
+		<th class="sorting-arrows">
 			<i class="fa fa-arrow-up"></i>
 			<i class="fa fa-arrow-down"></i>
 		</th>

--- a/_lib/cms/_tpl/list.php
+++ b/_lib/cms/_tpl/list.php
@@ -63,7 +63,7 @@ foreach( $where as $k=>$v ){
 <tbody id="items_<?=underscored($this->section);?>">
 <tr>
 	<? if( $sortable ){ ?>
-		<th width="16" style="text-align:center;">
+		<th width="37" class="sorting-arrows">
 			<i class="fa fa-arrow-up"></i>
 			<i class="fa fa-arrow-down"></i>
 		</th>
@@ -321,4 +321,3 @@ foreach( $vars['content'] as $v){
 	<td width="33%" style="text-align:right;"><?=$p->items_per_page();?>&nbsp;</td>
 </tr>
 </table>
-

--- a/_lib/cms/css/cms-new.css
+++ b/_lib/cms/css/cms-new.css
@@ -475,6 +475,7 @@ box-shadow: 0 0 5px 2px rgba(0,0,0,0.05);
 }
 .sorting-arrows {
 	text-align: left;
+	width: 37px;
 }
 .sorting-arrows i {
 	float: left;

--- a/_lib/cms/css/cms-new.css
+++ b/_lib/cms/css/cms-new.css
@@ -473,3 +473,12 @@ box-shadow: 0 0 5px 2px rgba(0,0,0,0.05);
 	margin-bottom: 20px;
 
 }
+.sorting-arrows {
+	text-align: left;
+}
+.sorting-arrows i {
+	float: left;
+}
+.sorting-arrows i:first-child {
+	margin-right: 5px;
+}


### PR DESCRIPTION
Added a float so the sort arrows appear side by side instead of 1 above
the other.

When stacked on top of each other, the other headings that are sortable
have an fa-arrow-down out of place . This resolves this issue.
